### PR TITLE
Rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+.env
+config.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,22 @@
 [package]
-name = "most_based_bot"
-version = "0.1.0"
+name = "reaction_toplist_bot"
+version = "0.2.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-serenity = "0.10"
 chrono = "0.4.19"
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-rayon = "1.3.0"
-tera = "1.15.0"
-lazy_static = "1.4.0"
-serde_json = "1.0.79"
-serde = "1.0.136"
-url = "2.2.2"
 linkify = "0.8.0"
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+toml = "0.5"
+
+[dependencies.serenity]
+version = "0.10"
+default-features = false
+features = [
+    "builder",
+    "client",
+    "rustls_backend",
+    "gateway",
+    "model",
+]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2022 Infi
+Copyright (c) 2022 FichteFoll <fichtefoll2@googlemail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
-# Based_Bot
-Random discord bot for counting emote usage in a given time
+# Reaction Toplist Bot
+
+Discord bot for building toplists for configured emoji reactions
+for the given ISO calendar week (Mon-Sun)
+and posting them in threads.
+
+
+## Usage
+
+You must set the `DISCORD_TOKEN` environment variable
+and invite the bot to your server.
+
+You may use the following URL
+to invite [a bot from your applications](https://discordapp.com/developers/applications/me)
+to your server:
+
+```
+https://discord.com/api/oauth2/authorize?client_id=<insert_client_id_here>&scope=bot&permissions=309237727232
+```
+
+Refer also to [the Discord OAuth2 documentation](https://discordapp.com/developers/docs/topics/oauth2).
+
+Afterwards, build and run the bot using your preferred method.
+
+```sh
+$ export DISCORD_TOKEN=<your_token_here>
+$ cargo run
+# or
+$ cargo build --release
+$ ./target/release/reaction_toplist_bot
+```
+
+
+## Configuration
+
+A configuration file is read from `./config.toml`
+relative to the current working directory.
+See [example-config.toml](./example-config.toml) for an example configuration.
+
+
+## Run-time Arguments
+
+The calendar week (the first parameter)
+can either be a relative number `+0`, `-1`
+or an absolute week for a given year
+in the format `yyyy-ww`, e.g. `2022-10`.
+Defaults to the current week if not specified.
+
+Examples:
+
+```sh
+$ reaction_toplist_bot
+$ reaction_toplist_bot -1
+$ reaction_toplist_bot 2022-10
+```

--- a/example-config.toml
+++ b/example-config.toml
@@ -1,0 +1,20 @@
+channel_id = 292651939555049472
+
+[[toplist]]
+max = 15 # this is the default
+emoji.name = "yes"
+emoji.id = 1000377617683333210
+
+[[toplist]]
+emoji.name = "no"
+emoji.id = 688706987290394635
+
+[[toplist]]
+emoji.string = "🙃"
+
+[other]
+enabled = true
+max = 15 # also the default
+ignore = [
+    { string = "♻\ufe0f" }, # Sometimes discord has this extra char
+]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,49 @@
+use std::{path::Path, error::Error};
+
+use serde::Deserialize;
+use serenity::model::id::{ChannelId, EmojiId};
+
+fn default_max() -> usize {
+    15
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Config {
+    pub channel_id: ChannelId,
+    pub toplist: Vec<Toplist>,
+    pub other: Other,
+}
+
+impl Config {
+    pub fn from_path(path: &Path) -> Result<Config, Box<dyn Error>> {
+        let contents = std::fs::read_to_string(path)?;
+        Ok(toml::from_str(&contents)?)
+    }
+}
+
+
+#[derive(Deserialize, Debug)]
+pub struct Toplist {
+    #[serde(default = "default_max")]
+    pub max: usize,
+    pub emoji: Emoji,
+}
+
+
+#[derive(Deserialize, Debug)]
+pub struct Other {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_max")]
+    pub max: usize,
+    #[serde(default)]
+    pub ignore: Vec<Emoji>,
+}
+
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+#[serde(untagged)]
+pub enum Emoji {
+    Custom { name: String, id: EmojiId },
+    Unicode { string: String },
+}

--- a/src/time_utils.rs
+++ b/src/time_utils.rs
@@ -1,0 +1,47 @@
+use chrono::*;
+
+pub fn parse_iso_week(week_param_opt: Option<&str>) -> Result<IsoWeek, Box<dyn std::error::Error>> {
+    let week_param = week_param_opt.unwrap_or("+0");
+    let first_char = week_param.chars().next().ok_or("week parameter empty")?;
+    if first_char == '+' || first_char == '-' {
+        let week_offset: i64 = week_param.parse()?;
+        let today = Local::today();
+        let target_day = today + Duration::weeks(week_offset);
+        Ok(target_day.iso_week())
+    } else {
+        let (year_str, week_str) = week_param.split_once("-").ok_or("bad iso week format (expected `yyyy-ww`)")?;
+        let date_opt = NaiveDate::from_isoywd_opt(year_str.parse()?, week_str.parse()?, Weekday::Mon);
+        Ok(date_opt.ok_or("invalid ISO week")?.iso_week())
+    }
+}
+
+pub fn iso_week_to_datetime(naive: IsoWeek) -> DateTime<Utc> {
+    let naive_date = NaiveDate::from_isoywd(naive.year(), naive.week(), Weekday::Mon);
+    DateTime::from_utc(naive_date.and_hms(0, 0, 0), Utc)
+}
+
+
+/// Discord's epoch starts at "2015-01-01T00:00:00+00:00"
+const DISCORD_EPOCH: u64 = 1_420_070_400_000;
+
+/// Create a numeric snowflake (id) pretending to be created at the provided unix timestamp.
+/// Intented for usage in time-relative APIs suchas serenity::GetMessages
+///
+/// When using as the lower end of a range, use `time_snowflake(…, false)`
+/// to be exclusive, `- 1` to be inclusive.
+///
+/// When using as the higher end of a range, use `time_snowflake(…, true)`
+/// to be exclusive, `+ 1` to be inclusive.
+///
+/// Inspired by discord.py:
+/// https://github.com/Rapptz/discord.py/blob/dc50736bfc3340d7b999d9f165808f8dcb8f1a60/discord/utils.py#L373
+pub fn time_snowflake(datetime: DateTime<Utc>, high: bool) -> u64 {
+    let discord_millis = datetime.timestamp_millis() as u64 - DISCORD_EPOCH;
+    (discord_millis << 22) + (if high { (1 << 22) - 1 } else { 0 })
+}
+
+/// Extract the timestamp of a snowflake (id).
+pub fn snowflake_time<T: Into<u64>>(id: T) -> DateTime<Utc> {
+    Utc.timestamp_millis(((id.into() >> 22) + DISCORD_EPOCH) as i64)
+}
+

--- a/src/toplist.rs
+++ b/src/toplist.rs
@@ -1,0 +1,130 @@
+use std::cmp::Ordering;
+use std::collections::{HashMap, BTreeSet};
+
+use linkify::LinkFinder;
+use serenity::model::channel::{Message, ReactionType, MessageReaction};
+
+use crate::config::{Config, Emoji};
+
+#[derive(Debug)]
+pub struct Toplist<'c> {
+    config: &'c Config,
+    pub top: HashMap<Option<Emoji>, BTreeSet<MsgWrap>>,
+    link_finder: LinkFinder,
+    other_ignore: Vec<Emoji>,
+}
+
+impl<'c> Toplist<'c> {
+    pub fn new(config: &'c Config) -> Self {
+        let mut other_ignore = config.other.ignore.clone();
+        other_ignore.extend(config.toplist.iter().map(|e| e.emoji.clone()));
+        Toplist {
+            config,
+            top: HashMap::new(),
+            link_finder: LinkFinder::new(),
+            other_ignore,
+        }
+    }
+
+    pub fn append(&mut self, message: &Message) {
+        let content = self.find_content(message);
+
+        self.append_known(message, &content);
+        if self.config.other.enabled {
+            self.append_other(message, &content);
+        }
+    }
+
+    fn find_content(&self, message: &Message) -> String {
+        match message.attachments.first() {
+            Some(t) => t.url.clone(),
+            None => {
+                let links: Vec<_> = self.link_finder.links(&message.content).collect();
+                links.first()
+                    .map(|s| s.as_str().to_string())
+                    // TODO or discard if no link?
+                    .unwrap_or_else(|| message.content.clone())
+            }
+        }
+    }
+
+    fn append_known(&mut self, message: &Message, content: &str) {
+        for entry in self.config.toplist.iter() {
+            let count_opt = message.reactions.iter().find_map(|r| is_same_emoji(r, &entry.emoji).then_some(r.count));
+            if let Some(count) = count_opt {
+                if let Some(list) = self.prepate_for_insert(Some(entry.emoji.clone()), entry.max, count) {
+                    let msg_wrap = MsgWrap { count, message: message.clone(), content: content.to_string() };
+                    list.insert(msg_wrap);
+                }
+            }
+        }
+    }
+
+    fn append_other(&mut self, message: &Message, content: &str) {
+        // TODO Unfortunately we cannot count distinct reactors here
+        let stripped_reactions: Vec<_> = message.reactions.iter()
+            .filter(|r| !self.other_ignore.iter().any(|ignore| is_same_emoji(r, ignore)))
+            .cloned()
+            .collect();
+        let count: u64 = stripped_reactions.iter().map(|e| e.count - e.me as u64).sum();
+        if let Some(list) = self.prepate_for_insert(None, self.config.other.max, count) {
+            let mut message = message.clone();
+            message.reactions = stripped_reactions;
+            let msg_wrap = MsgWrap { count, message, content: content.to_string() };
+            list.insert(msg_wrap);
+        };
+    }
+
+    fn prepate_for_insert(&mut self, emoji: Option<Emoji>, max: usize, count: u64) -> Option<&mut BTreeSet<MsgWrap>> {
+        if count == 0 {
+            return None;
+        }
+        let list = self.top.entry(emoji).or_insert_with(BTreeSet::default);
+        let min = list.first().map(|mw| mw.count).unwrap_or(0);
+        if min > count {
+            return None;
+        }
+        if list.len() == max {
+            list.pop_first();
+        }
+        Some(list)
+    }
+}
+
+fn is_same_emoji(r: &MessageReaction, emoji: &Emoji) -> bool {
+    match (&r.reaction_type, emoji) {
+        (ReactionType::Custom { id, ..}, Emoji::Custom { id: id2, .. })
+            if id == id2 => true,
+        (ReactionType::Unicode(s), Emoji::Unicode { string, .. })
+            if s == string => true,
+        _ => false,
+    }
+}
+
+#[derive(Debug)]
+pub struct MsgWrap {
+    pub count: u64, // must be first for auto-deriving ordering
+    pub content: String,
+    pub message: Message,
+}
+
+impl PartialEq for MsgWrap {
+    fn eq(&self, other: &Self) -> bool {
+        self.message.id == other.message.id
+    }
+}
+
+impl Eq for MsgWrap {}
+
+impl PartialOrd for MsgWrap {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for MsgWrap {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.count.cmp(&other.count)
+            .then_with(|| self.message.id.cmp(&other.message.id))
+    }
+}


### PR DESCRIPTION
Now uses a command line mode to execute once instead of sitting idle and
waiting for commands from users. This can then be invoked periodically
by a systemd timer or cron job.

Also has extensive-ish configuration read from a file now and supports
an "Other" toplist of all messages that didn't make it into any of the
other toplists already.

Updates #1 (doesn't count distinct reaction authors for a message).